### PR TITLE
Used mu4e setting to decide moving draft to sent folder

### DIFF
--- a/mu4e-send-delay.el
+++ b/mu4e-send-delay.el
@@ -278,9 +278,10 @@ than current time and is not currently being edited."
       (message-remove-header "fcc" nil)
       (message-remove-header mu4e-send-delay-header nil)
 
-      ;; write mail to Sent-folder
-      (when file
-        (write-file file))
+      ;; write mail to Sent-folder if set in mu4e
+      (when (equal 'mu4e-sent-messages-behavior 'sent)
+	(when file
+          (write-file file)))
 
       (set-buffer-modified-p nil)
       (kill-buffer (current-buffer))

--- a/mu4e-send-delay.el
+++ b/mu4e-send-delay.el
@@ -279,7 +279,7 @@ than current time and is not currently being edited."
       (message-remove-header mu4e-send-delay-header nil)
 
       ;; write mail to Sent-folder if set in mu4e
-      (when (equal 'mu4e-sent-messages-behavior 'sent)
+      (when (member mu4e-sent-messages-behavior '(sent))
 	(when file
           (write-file file)))
 

--- a/mu4e-send-delay.el
+++ b/mu4e-send-delay.el
@@ -279,7 +279,7 @@ than current time and is not currently being edited."
       (message-remove-header mu4e-send-delay-header nil)
 
       ;; write mail to Sent-folder if set in mu4e
-      (when (member mu4e-sent-messages-behavior '(sent))
+      (when (eq mu4e-sent-messages-behavior 'sent)
 	(when file
           (write-file file)))
 


### PR DESCRIPTION
Closes #17. The problem there is due to IMAP. The email is written to the Sent folder once upon sending and then again when pulling emails from the server. Hence the discrepancy in times and in the appearance of attachments. See also a [thread on Emacs StackExchange](https://emacs.stackexchange.com/questions/50263/emails-sent-twice-in-mu4e-with-send-delay/50267#50267).

This pull request uses the `mu4e` setting: unless `mu4e-sent-messages-behavior` is set to `'sent`, emails are not copied to sent items upon sending, thus avoiding duplication, but needing a sync to appear in the sent folder.