### PR TITLE
Now obsolete variables updated for mu 1.4.12

### DIFF
--- a/mu4e-send-delay.el
+++ b/mu4e-send-delay.el
@@ -301,7 +301,7 @@ than current time and is not currently being edited."
 
 (defun mu4e-send-delay-get-drafts-folder ()
   (expand-file-name
-   (concat mu4e-maildir (mu4e-get-drafts-folder) "/cur")))
+   (concat (mu4e-root-maildir) (mu4e-get-drafts-folder) "/cur")))
 
 (defun mu4e-send-delay-send-queue ()
   "Send all delayed mails that are due now."
@@ -342,8 +342,7 @@ than current time and is not currently being edited."
     "Construct the common headers for each message."
     (concat
      (mu4e~draft-header "User-agent" mu4e-user-agent-string)
-     (when mu4e-compose-auto-include-date
-       (mu4e~draft-header "Date" (message-make-date)))
+     (mu4e~draft-header "Date" (message-make-date))
      (when mu4e-send-delay-include-header-in-draft
        (mu4e~draft-header mu4e-send-delay-header mu4e-send-delay-default-delay)))))
 


### PR DESCRIPTION
`mu4e-maildir` has [been obsolete since 1.3.8](https://github.com/djcb/mu/blob/c4e8a8f04c64a1f34096e668c7c172f6c3a4e605/mu4e/mu4e-vars.el#L60-L61)

 `mu4e-compose-auto-include-date` has [been obsolete since 1.3.5](https://github.com/djcb/mu/blob/e10fc21a9b76a33f5b8ffa46e793203eb1e0cb89/mu4e/mu4e-draft.el#L68-L69)

Respectfully submitted